### PR TITLE
support non-project forms

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@formspree/core",
-  "version": "2.5.2",
+  "version": "2.6.1",
   "description": "The core library for Formspree",
   "homepage": "https://formspree.io",
   "bugs": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,15 +10,15 @@ import { clientHeader, encode64 } from './utils';
 import { Session } from './session';
 
 export interface Config {
-  projectKey?: string;
+  project?: string;
 }
 
 export class Client {
-  projectKey: string | undefined;
+  project: string | undefined;
   private session: Session | undefined;
 
   constructor(config: Config = {}) {
-    this.projectKey = config.projectKey;
+    this.project = config.project;
     if (typeof window !== 'undefined') this.startBrowserSession();
   }
 
@@ -52,8 +52,8 @@ export class Client {
   ): Promise<SubmissionResponse> {
     let endpoint = opts.endpoint || 'https://formspree.io';
     let fetchImpl = opts.fetchImpl || fetchPonyfill({ Promise }).fetch;
-    let url = this.projectKey
-      ? `${endpoint}/p/${this.projectKey}/f/${formKey}`
+    let url = this.project
+      ? `${endpoint}/p/${this.project}/f/${formKey}`
       : `${endpoint}/f/${formKey}`;
 
     const serializeBody = (data: SubmissionData): FormData | string => {

--- a/test/submitForm.test.js
+++ b/test/submitForm.test.js
@@ -25,11 +25,11 @@ it('resolves with body and response when successful', () => {
   const mockFetch = (url, props) => {
     expect(props.method).toEqual('POST');
     expect(props.mode).toEqual('cors');
-    expect(url).toEqual('https://formspree.io/p/111/f/newsletter');
+    expect(/^https:\/\/.+\/p\/111\/f\/newsletter$/.test(url)).toEqual(true);
     return success;
   };
 
-  return createClient({ projectKey: '111' })
+  return createClient({ project: '111' })
     .submitForm(
       'newsletter',
       {},
@@ -50,7 +50,7 @@ it('uses the form URL when no project key is provided', () => {
   const mockFetch = (url, props) => {
     expect(props.method).toEqual('POST');
     expect(props.mode).toEqual('cors');
-    expect(url).toEqual('https://formspree.io/f/xxyyhashid');
+    expect(/^https:\/\/.+\/f\/xxyyhashid$/.test(url)).toEqual(true);
     return success;
   };
 
@@ -80,7 +80,7 @@ it('uses a default client header if none is given', () => {
     return success;
   };
 
-  return createClient({ projectKey: '111' }).submitForm(
+  return createClient({ project: '111' }).submitForm(
     'newsletter',
     {},
     {
@@ -98,7 +98,7 @@ it('puts given client name in the client header', () => {
     return success;
   };
 
-  return createClient({ projectKey: '111' }).submitForm(
+  return createClient({ project: '111' }).submitForm(
     'newsletter',
     {},
     {
@@ -117,7 +117,7 @@ it('sets content type to json if data is not FormData', () => {
     return success;
   };
 
-  return createClient({ projectKey: '111' }).submitForm(
+  return createClient({ project: '111' }).submitForm(
     'newsletter',
     { foo: 'bar' },
     { fetchImpl: mockFetch }
@@ -133,7 +133,7 @@ it('sends telemetry data if session is started', () => {
     return success;
   };
 
-  const client = createClient({ projectKey: '111' });
+  const client = createClient({ project: '111' });
   client.startBrowserSession();
   return client.submitForm('newsletter', {}, { fetchImpl: mockFetch });
 });


### PR DESCRIPTION
It would be great if formspree-core could handle non-project forms. These forms submit to an endpoint of the form `https://formspree.io/f/{formid}` rather than `https://formspree.io/p/{projectKey}/f/{formKey}`. 

My simple work-around is if the client doesn't receive a projectKey, assume it's a non-project form and use the appropriate endpoint.