### PR TITLE
reverting to projectKey

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,15 +10,15 @@ import { clientHeader, encode64 } from './utils';
 import { Session } from './session';
 
 export interface Config {
-  project?: string;
+  projectKey?: string;
 }
 
 export class Client {
-  project: string | undefined;
+  projectKey: string | undefined;
   private session: Session | undefined;
 
   constructor(config: Config = {}) {
-    this.project = config.project;
+    this.projectKey = config.projectKey;
     if (typeof window !== 'undefined') this.startBrowserSession();
   }
 
@@ -52,8 +52,8 @@ export class Client {
   ): Promise<SubmissionResponse> {
     let endpoint = opts.endpoint || 'https://formspree.io';
     let fetchImpl = opts.fetchImpl || fetchPonyfill({ Promise }).fetch;
-    let url = this.project
-      ? `${endpoint}/p/${this.project}/f/${formKey}`
+    let url = this.projectKey
+      ? `${endpoint}/p/${this.projectKey}/f/${formKey}`
       : `${endpoint}/f/${formKey}`;
 
     const serializeBody = (data: SubmissionData): FormData | string => {

--- a/test/submitForm.test.js
+++ b/test/submitForm.test.js
@@ -29,7 +29,7 @@ it('resolves with body and response when successful', () => {
     return success;
   };
 
-  return createClient({ project: '111' })
+  return createClient({ projectKey: '111' })
     .submitForm(
       'newsletter',
       {},
@@ -80,7 +80,7 @@ it('uses a default client header if none is given', () => {
     return success;
   };
 
-  return createClient({ project: '111' }).submitForm(
+  return createClient({ projectKey: '111' }).submitForm(
     'newsletter',
     {},
     {
@@ -98,7 +98,7 @@ it('puts given client name in the client header', () => {
     return success;
   };
 
-  return createClient({ project: '111' }).submitForm(
+  return createClient({ projectKey: '111' }).submitForm(
     'newsletter',
     {},
     {
@@ -117,7 +117,7 @@ it('sets content type to json if data is not FormData', () => {
     return success;
   };
 
-  return createClient({ project: '111' }).submitForm(
+  return createClient({ projectKey: '111' }).submitForm(
     'newsletter',
     { foo: 'bar' },
     { fetchImpl: mockFetch }
@@ -133,7 +133,7 @@ it('sends telemetry data if session is started', () => {
     return success;
   };
 
-  const client = createClient({ project: '111' });
+  const client = createClient({ projectKey: '111' });
   client.startBrowserSession();
   return client.submitForm('newsletter', {}, { fetchImpl: mockFetch });
 });


### PR DESCRIPTION
The reason I changed to project id was because that's clearly something you can put in your code. Project Key feels like it should be a secret.

I think project key could be OK if the API is clear to put the projectKey in your code. But if the argument is "project", people may still question if putting their project key there is appropriate.