### PR TITLE
feat(types): export form body types

### DIFF
--- a/src/forms.ts
+++ b/src/forms.ts
@@ -6,12 +6,12 @@ export interface SubmissionOptions {
   fetchImpl?: typeof fetch;
 }
 
-interface SuccessBody {
+export interface SuccessBody {
   id: string;
   data: object;
 }
 
-interface ErrorBody {
+export interface ErrorBody {
   errors: Array<{
     field?: string;
     code: string | null;


### PR DESCRIPTION
exports `SuccessBody` and `ErrorBody` so users can cast response bodies 

### Motivation

I'm using [formspree/formspree-react](https://github.com/formspree/formspree-react) with [jaredpalmer/formik](https://github.com/jaredpalmer/formik). After I submit the form, I need to set any uncaught errors on the `Formik`:

```tsx
<Formik
  ...
  onSubmit={async (values, { setErrors }) => {
    const { body } = await handleSubmit(values)
    if (body.errors)
      setErrors(
        body.errors
          .filter((x): x is Required<typeof x> => !!x.field)
          .reduce(
            (acc, cur) => ({
              ...acc,
              [cur.field]: cur.message,
            }),
            {} as Parameters<typeof setErrors>[0]
          )
      )
  }}
>
```

TypeScript doesn't like when you access a property of `body`:

```
Property 'errors' does not exist on type 'SubmissionBody'.
  Property 'errors' does not exist on type 'SuccessBody' (ts.2339)
```

Right now, you can get around this with a one-liner thanks to [type-fest](https://github.com/sindresorhus/type-fest)'s `UnionToIntersection`...

```tsx
const { errors } = (body as Partial<UnionToIntersection<typeof body>>)
```

...but this isn't perfect—after collapsing the union, `body` is no longer narrowable to `SuccessBody` or `ErrorBody`.