### PR TITLE
feat(types): unify body types

### DIFF
--- a/src/forms.ts
+++ b/src/forms.ts
@@ -13,7 +13,7 @@ interface ValidationError {
 }
 
 interface SubmissionBodyBase {
-  errors?: ValidationError[]
+  errors?: ValidationError[];
   id?: string;
   data?: object;
 }
@@ -24,11 +24,7 @@ interface SuccessBody extends SubmissionBodyBase {
 }
 
 interface ErrorBody extends SubmissionBodyBase {
-  errors: Array<{
-    field?: string;
-    code: string | null;
-    message: string;
-  }>;
+  errors: ValidationError[];
 }
 
 export type SubmissionBody = SuccessBody | ErrorBody;

--- a/src/forms.ts
+++ b/src/forms.ts
@@ -6,12 +6,24 @@ export interface SubmissionOptions {
   fetchImpl?: typeof fetch;
 }
 
-interface SuccessBody {
+interface ValidationError {
+  field?: string;
+  code: string | null;
+  message: string;
+}
+
+interface SubmissionBodyBase {
+  errors?: ValidationError[]
+  id?: string;
+  data?: object;
+}
+
+interface SuccessBody extends SubmissionBodyBase {
   id: string;
   data: object;
 }
 
-interface ErrorBody {
+interface ErrorBody extends SubmissionBodyBase {
   errors: Array<{
     field?: string;
     code: string | null;


### PR DESCRIPTION
complementary to #4, this fixes the `SubmissionBody` type to prevent inaccurate property access errors and enable proper [narrowing](https://www.typescriptlang.org/docs/handbook/2/narrowing.html) to `SuccessBody` and `ErrorBody`

### Motivation

See #4